### PR TITLE
Filter out non-stacked windows (stack-index 0) in stack mode

### DIFF
--- a/tests/test_yabai_layout_details.py
+++ b/tests/test_yabai_layout_details.py
@@ -73,19 +73,23 @@ def test_filter_windows():
     test_data = [
         {
             "window_id": 1,
-            "app": "VSCode"
+            "app": "VSCode",
+            "stack-index": 1
         },
         {
             "window_id": 2,
-            "app": "Hammerspoon"
+            "app": "Hammerspoon",
+            "stack-index": 2
         },
         {
             "window_id": 3,
-            "app": "Hammerspoon"
+            "app": "Hammerspoon",
+            "stack-index": 3
         },
         {
             "window_id": 4,
-            "app": "iTerm2"
+            "app": "iTerm2",
+            "stack-index": 4
         },
     ]
 
@@ -95,3 +99,35 @@ def test_filter_windows():
     assert (len(results) == 2)
     assert (results[0]["window_id"] == 1 and results[0]["app"] == "VSCode")
     assert (results[1]["window_id"] == 4 and results[1]["app"] == "iTerm2")
+
+
+def test_filter_windows_excludes_non_stacked_windows():
+    test_data = [
+        {
+            "window_id": 1,
+            "app": "Wispr Flow",
+            "stack-index": 0
+        },
+        {
+            "window_id": 2,
+            "app": "VK Calls",
+            "stack-index": 0
+        },
+        {
+            "window_id": 3,
+            "app": "iTerm2",
+            "stack-index": 1
+        },
+        {
+            "window_id": 4,
+            "app": "Code",
+            "stack-index": 2
+        },
+    ]
+
+    layout_details = YabaiLayoutDetails()
+    results = layout_details.filter_windows(test_data)
+
+    assert (len(results) == 2)
+    assert (results[0]["window_id"] == 3 and results[0]["app"] == "iTerm2")
+    assert (results[1]["window_id"] == 4 and results[1]["app"] == "Code")

--- a/yabai_stack_navigator/yabai_layout_details.py
+++ b/yabai_stack_navigator/yabai_layout_details.py
@@ -72,4 +72,5 @@ class YabaiLayoutDetails:
         return [
             window for window in window_data
             if window["app"] not in YabaiLayoutDetails.AppsToFilterOut
+            and window.get("stack-index", 0) > 0
         ]


### PR DESCRIPTION
## Problem

When using stack layout, `filter_windows` only filters by app name (Hammerspoon, Kap). However, windows with `stack-index: 0` — such as floating/sticky dialogs (e.g. Wispr Flow) or invisible windows without AX reference (e.g. VK Calls) — are not part of the stack but are included in navigation.

This causes the navigator to wrap around to an unfocusable window, which then breaks subsequent navigation with `"Shouldn't get here"` exception because no window reports `has-focus: True`.

## Fix

Added a `stack-index > 0` check to `filter_windows` so that only actual stacked windows are included in navigation. Windows with `stack-index: 0` are excluded since they are not part of the stack (yabai assigns `stack-index >= 1` to stacked windows).

## Testing

- Updated existing `test_filter_windows` to include `stack-index` in test data
- Added `test_filter_windows_excludes_non_stacked_windows` to verify the fix
- All 12 tests pass